### PR TITLE
Correct html2text options: python-html2text doesn't have a -style option

### DIFF
--- a/pacmatic
+++ b/pacmatic
@@ -129,7 +129,7 @@ check_news()  # none : news (logfile)
     if [ $(( $this_date )) -gt $(( $last_news_date )) ]; then
         line3=$(cut -d ' ' -f 2- <<< "$line2")
         if which html2text >& /dev/null; then
-            echo "$line3" | html2text -style pretty | sed 's/\\n$//'
+            echo "$line3" | sed -e 's|\\n||g' | html2text -b 0
         else
             echo "$line3" | sed -e 's|<br />|\n|g' -e 's|\\n||g' -e 's|<p>|\n|g' -e 's|</p>||g'
         fi


### PR DESCRIPTION
In arch html2text is provided by python-html2text which doesn't have a -style option.

Fix how the output is printed to reflex that.