### PR TITLE
Using LC_ALL instead of LC_TIME as it does not seem to work on month names

### DIFF
--- a/pacmatic
+++ b/pacmatic
@@ -3,7 +3,7 @@
 # configs
 warn_time="${warn_time:-86400}"  # seconds
 rss_feed="${rss_feed:-https://www.archlinux.org/feeds/news/}"
-mail_list="${mail_list:-https://lists.archlinux.org/pipermail/arch-general/$(LC_TIME=C printf '%(%Y-%B)T\n' -1).txt.gz}"
+mail_list="${mail_list:-https://lists.archlinux.org/pipermail/arch-general/$(LC_ALL=C printf '%(%Y-%B)T\n' -1).txt.gz}"
 log_file="${log_file:-/var/log/arch-news.log}"
 pacman_log="${pacman_log:-/var/log/pacman.log}"
 pacdiff_program="${pacdiff_program:-pacdiff}"


### PR DESCRIPTION
I replaced LC_TIME by LC_ALL. Works fine now. Otherwise I wasn't able to download the mailinglist archive files, because the names of month were german.
