### PR TITLE
Handle missing mailing list archive

### DIFF
--- a/pacmatic
+++ b/pacmatic
@@ -39,15 +39,17 @@ mail_summary()  # None : None, set $mail_counts and save new stamp
     if [ -f "$config" ]; then
         stamp=$(cat "$config")
     fi
-    raw=$(curl -s "$mail_list" | zcat | sed -n "/$stamp/,\$p")
-    if [ -z "$raw" ]; then
-        # inefficient, but should only happen once a month
-        raw=$(curl -s "$mail_list" | zcat)
+    raw=$(curl -s "$mail_list" | (zcat 2>/dev/null))
+    if [ -n "$raw" ]; then
+        update=$(sed -n "/$stamp/,\$p" <<< "$raw")
+        if [ -n "$update" ]; then
+            raw=$update
+        fi
+        new_stamp=$(grep '^Date' <<< "$raw" | tail -n 1)
+        mail_counts=$(grep -oF "$(expac -Q ' %n-')" <<< "$raw" | sort | uniq -c | sort -nr  | awk '{sub(/-$/,"",$2); if(NR!=1) printf ", "; printf "%s(%s)",$2,$1}')
+        mkdir -p $(dirname "$config")
+        echo "$new_stamp" > "$config"
     fi
-    new_stamp=$(grep '^Date' <<< "$raw" | tail -n 1)
-    mail_counts=$(grep -oF "$(expac -Q ' %n-')" <<< "$raw" | sort | uniq -c | sort -nr  | awk '{sub(/-$/,"",$2); if(NR!=1) printf ", "; printf "%s(%s)",$2,$1}')
-    mkdir -p $(dirname "$config")
-    echo "$new_stamp" > "$config"
 }
 
 clean_rss()  # none : xml


### PR DESCRIPTION
When there are no gzipped mailing list archives, mail_summary()
passes curl's 404 HTML contents to zcat which promptly shows
the user "gzip: stdin: not in gzip format".

Allow for the possibility that this can happen briefly at the
beginning of a new month (no mail messages to the mailing list),
and don't bother showing the zcat error to the user: it doesn't
help them understand what's going on, and there's nothing they
can do.