### PR TITLE
Add a systemd timer for cron-pacmatic

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # $Id: PKGBUILD 100043 2013-10-31 15:45:57Z kkeen $
 # Maintainer: Kyle Keen <keenerd@gmail.com>
 pkgname=pacmatic
-pkgver=20141006
+pkgver=20160415
 pkgrel=1
 pkgdesc="A pacman wrapper to avoid bricking your system and such other surprises."
 arch=('any')
@@ -19,9 +19,11 @@ md5sums=('1fe11adaa39aae9d3146ddbc3808eb23'
 
 package() {
   cd "$srcdir/$pkgname"
-  install -Dm0755 pacmatic      "$pkgdir/usr/bin/pacmatic"
-  install -Dm0755 cron-pacmatic "$pkgdir/usr/bin/cron-pacmatic"
-  install -Dm0644 pacmatic.1    "$pkgdir/usr/share/man/man1/pacmatic.1"
-  install -Dm0644 ../_pacmatic  "$pkgdir/usr/share/zsh/site-functions/_pacmatic"
+  install -Dm0755 pacmatic          "$pkgdir/usr/bin/pacmatic"
+  install -Dm0755 cron-pacmatic     "$pkgdir/usr/bin/cron-pacmatic"
+  install -Dm0644 pacmatic.1        "$pkgdir/usr/share/man/man1/pacmatic.1"
+  install -Dm0644 ../_pacmatic      "$pkgdir/usr/share/zsh/site-functions/_pacmatic"
+  install -Dm0644 pacmatic@.service "$pkgdir/usr/lib/systemd/system/pacmatic@.service"
+  install -Dm0644 pacmatic@.timer   "$pkgdir/usr/lib/systemd/system/pacmatic@.timer"
 }
 

--- a/cron-pacmatic
+++ b/cron-pacmatic
@@ -36,5 +36,5 @@ if [[ -n $packages ]]; then
     echo "Recent ML chatter: $mail_counts" >> $mail_body
     echo "Pacman updates: $packages"       >> $mail_body
     cat $mail_body |\
-        mail -s "Updates available on $(hostname)" $1
+        mail -# -s "Updates available on $(hostname)" $1
 fi

--- a/pacmatic.1
+++ b/pacmatic.1
@@ -58,7 +58,11 @@ In case you want even higher levels of automation, there is a
 .Nm cron-pacmatic
 script.  This script can be run periodically and will email you a summary of
 .Nm
-output.
+output. The
+.Nm pacmatic@.timer
+systemd unit is provided to schedule it. Enable it as
+.Ic pacmatic@ Ns Em your\ex40mail.tld Ns Ic .timer
+(with escaping).
 .Pp
 .Sh AUTHORS
 .An -nosplit

--- a/pacmatic@.service
+++ b/pacmatic@.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Email list of pending updates to %I
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/cron-pacmatic %I

--- a/pacmatic@.timer
+++ b/pacmatic@.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Email list of pending updates to %I timer
+
+[Timer]
+OnCalendar=daily UTC
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Given that the vast majority of Arch systems run systemd, it makes sense to include a systemd timer for cron-pacmatic. By default it will run daily (easily overridden by a drop-in), and it's instantiated to allow easy customisation of the destination address (tested with both local mailboxes and remote addresses).

One change (enabling batch mode for mail) was necessary to cron-pacmatic in order for it to function within a systemd unit at all, and ideally should be present even if the decision is made not to distribute a systemd unit as part of the package.
