### PR TITLE
Add Bash completion

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,15 +13,18 @@ optdepends=('vim: for vimdiff'
             'html2text: for prettier news'
             'fakeroot: for cron-pacmatic script')
 source=("http://kmkeen.com/$pkgname/$pkgname-$pkgver.tar.gz"
-        "_pacmatic")
+        "_pacmatic"
+        "pacmatic.bash-completion")
 md5sums=('1fe11adaa39aae9d3146ddbc3808eb23'
-         '1c369c8fe595cbb41d04e214efd39a1e')
+         '1c369c8fe595cbb41d04e214efd39a1e'
+         '915cca3c2306ba74b3973afd64217700')
 
 package() {
   cd "$srcdir/$pkgname"
-  install -Dm0755 pacmatic      "$pkgdir/usr/bin/pacmatic"
-  install -Dm0755 cron-pacmatic "$pkgdir/usr/bin/cron-pacmatic"
-  install -Dm0644 pacmatic.1    "$pkgdir/usr/share/man/man1/pacmatic.1"
-  install -Dm0644 ../_pacmatic  "$pkgdir/usr/share/zsh/site-functions/_pacmatic"
+  install -Dm0755 pacmatic                    "$pkgdir/usr/bin/pacmatic"
+  install -Dm0755 cron-pacmatic               "$pkgdir/usr/bin/cron-pacmatic"
+  install -Dm0644 pacmatic.1                  "$pkgdir/usr/share/man/man1/pacmatic.1"
+  install -Dm0644 ../_pacmatic                "$pkgdir/usr/share/zsh/site-functions/_pacmatic"
+  install -Dm0644 ../pacmatic.bash-completion "$pkgdir/usr/share/bash-completion/completions/pacmatic"
 }
 

--- a/pacmatic.bash-completion
+++ b/pacmatic.bash-completion
@@ -1,0 +1,22 @@
+# load upstream completion
+_completion_loader pacman
+
+# get upstream completion specification
+completion_spec=$(complete -p pacman)
+
+# use upstream specification for our own purpose
+#
+# for example, if this is upstream:
+#
+#     complete -o default -F _pacman pacman
+#
+# we want to turn that into this:
+#
+#     complete -o default -F _pacman pacmatic
+#
+eval "${completion_spec/ pacman/ pacmatic}"
+
+# clean up
+unset completion_spec
+
+# ex: filetype=sh


### PR DESCRIPTION
I use pacmatic every day, and am very happy to have it's automatic `.pac{new,save}` and mailing list checking as I'm upgrading.

One thing I've been missing is Bash completion for pacmatic. So I set out to create a Bash completion that's just a shim to pacman's completion.

This pull request adds that, wish some elaborate comments explaining how it's done (I don't think it's obvious without comments, because the bash-completion system has little documentation).

Would be very happy to see this code merged, as I would use the code every day :smile: In any case, thanks a lot for pacmatic!