### PR TITLE
Simplify zsh completion

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,7 +15,7 @@ optdepends=('vim: for vimdiff'
 source=("http://kmkeen.com/$pkgname/$pkgname-$pkgver.tar.gz"
         "_pacmatic")
 md5sums=('1fe11adaa39aae9d3146ddbc3808eb23'
-         '1c369c8fe595cbb41d04e214efd39a1e')
+         'b5ae396755d5859740b0b0e4df53d607')
 
 package() {
   cd "$srcdir/$pkgname"

--- a/_pacmatic
+++ b/_pacmatic
@@ -1,9 +1,7 @@
 #compdef pacmatic
 
-. /usr/share/zsh/site-functions/_pacman
-
 _pacmatic() {
-    _pacman_zsh_comp "$@"
+    _dispatch pacman pacman
 }
 
 _pacmatic "$@"


### PR DESCRIPTION
I noticed that the zsh completion could be simplified. I've seen this shim technique used in [RichiH/vcsh](https://github.com/RichiH/vcsh/blob/eadb8df6aa71a76e5be36492edcadb118bd862ac/_vcsh#L143-L144).